### PR TITLE
Clear up any confusion

### DIFF
--- a/docs/js-deps.adoc
+++ b/docs/js-deps.adoc
@@ -153,7 +153,7 @@ By default `shadow-cljs` will resolve all `(:require ["thing" :as x])` requires 
 Builds can use different directories for `node_modules` by setting :node-modules-dir.
 
 ```
-:js-options {:node-modules-dir "some/nested/path"}
+:js-options {:node-modules-dir "some/nested/path/node_modules"}
 ```
 
 ==== Using a CDN [[js-resolve-global]]


### PR DESCRIPTION
`:node-modules-dir` has to be the path up to the node modules themselves, not the directory containing `node_modules`.