### PR TITLE
Fix typo + create a Dockerfile to facilitate development and contribution

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "shadow-cljs.github.io",
+  "dockerFile": "Dockerfile",
+  "postCreateCommand": "bundle install"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM ruby:2-alpine
+RUN apk upgrade && apk add make

--- a/README.md
+++ b/README.md
@@ -7,4 +7,14 @@ The guide is written in asciidoc format available in the `/docs` directory.
 
 `make` is used to build the primary HTML file via [asciidoctor](http://asciidoctor.org/).
 
+## Contribution
+
 Contributions are very welcome. Just open an issue or pull request.
+
+### Dockerfile
+
+People who prefer developing against a Docker container can use the `Dockerfile` provided in this repository. It contains everything that you need:
+
+- Ruby
+- Bundler
+- Make

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ People who prefer developing against a Docker container can use the `Dockerfile`
 - Ruby
 - Bundler
 - Make
+
+### Visual Studio Code
+
+Provided that you have you have the "Visual Studio Code Remote - Container" extension installed, Visual Studio Code users will be able to develop against the Docker container immediately.

--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -6146,7 +6146,7 @@ cljs.repl&gt;</code></pre>
 <div class="sect2">
 <h3 id="cljs-repl-anatomy"><a class="anchor" href="#cljs-repl-anatomy"></a><a class="link" href="#cljs-repl-anatomy">14.1. Anatomy of the CLJS REPL</a></h3>
 <div class="paragraph">
-<p>A REPL in Clojure does exactly that the name implies: Read one form, Eval it, Print the result, Loop to do it again.</p>
+<p>A REPL in Clojure does exactly what the name implies: Read one form, Eval it, Print the result, Loop to do it again.</p>
 </div>
 <div class="paragraph">
 <p>In ClojureScript however things are a bit more complicated since compilation happens on the JVM but the results are eval&#8217;d in a JavaScript runtime. There are a couple more steps that need to be done due in order to "emulate" the plain REPL experience. Although things are implemented a bit differently in <code>shadow-cljs</code> over regular CLJS the basic principles remain the same.</p>
@@ -6372,7 +6372,7 @@ that project and understand its setup, build, etc.</p>
 <div id="footer">
 <div id="footer-text">
 Version 1.0<br>
-Last updated 2019-08-18 13:32:22 CEST
+Last updated 2019-09-22 13:25:29 UTC
 </div>
 </div>
 </body>

--- a/docs/repl-troubleshoot.adoc
+++ b/docs/repl-troubleshoot.adoc
@@ -6,7 +6,7 @@ image::shadow-cljs-repl.png[]
 
 ## Anatomy of the CLJS REPL [[cljs-repl-anatomy]]
 
-A REPL in Clojure does exactly that the name implies: Read one form, Eval it, Print the result, Loop to do it again.
+A REPL in Clojure does exactly what the name implies: Read one form, Eval it, Print the result, Loop to do it again.
 
 In ClojureScript however things are a bit more complicated since compilation happens on the JVM but the results are eval'd in a JavaScript runtime. There are a couple more steps that need to be done due in order to "emulate" the plain REPL experience. Although things are implemented a bit differently in `shadow-cljs` over regular CLJS the basic principles remain the same.
 


### PR DESCRIPTION
I found a typo that I wanted to fix but then realised I needed to have Ruby, Bundler and Make. I think that providing a dockerised development environment will facilitate and encourage external contribution.

I did this in three separate commits:

- The first one defines the Dockerfile
- The second one is VS Code specific
- The third one is the actual typo fix

If you prefer to keep Docker away, we can just ignore the first two commits.
