### PR TITLE
Fix CIDER variable name for build name

### DIFF
--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -5939,7 +5939,7 @@ cljs.repl&gt;</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="clojure">((<span class="predefined-constant">nil</span> <span class="keyword">.</span> ((cider-default-cljs-repl <span class="keyword">.</span> shadow)
-         (cider-shadow-cljs-default-options <span class="keyword">.</span> <span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;your-build-name-here&gt;</span><span class="delimiter">&quot;</span></span>))))</code></pre>
+         (cider-shadow-default-options <span class="keyword">.</span> <span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;your-build-name-here&gt;</span><span class="delimiter">&quot;</span></span>))))</code></pre>
 </div>
 </div>
 </div>
@@ -6378,7 +6378,7 @@ that project and understand its setup, build, etc.</p>
 <div id="footer">
 <div id="footer-text">
 Version 1.0<br>
-Last updated 2019-08-18 13:32:22 CEST
+Last updated 2019-09-29 11:41:42 BST
 </div>
 </div>
 </body>

--- a/docs/editor-integration.adoc
+++ b/docs/editor-integration.adoc
@@ -63,7 +63,7 @@ You can simplify startup flow by a creating a `dir-local.el` file at project roo
 
 ```
 ((nil . ((cider-default-cljs-repl . shadow)
-	 (cider-shadow-cljs-default-options . "<your-build-name-here>"))))
+	 (cider-shadow-default-options . "<your-build-name-here>"))))
 ```
 
 == Proto REPL (Atom)


### PR DESCRIPTION
The CIDER variable name for build name is `cider-shadow-default-options`, not `cider-shadow-cljs-default-options`.

Here's a link to the place in CIDER where it's defined (permalink to current master):
https://github.com/clojure-emacs/cider/blob/cc52e696e3647229f4075c90f267c33d0940757f/cider.el#L711