### PR TITLE
Fix Emacs dir-locals filename

### DIFF
--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -5934,7 +5934,7 @@ cljs.repl&gt;</code></pre>
 <div class="sect3">
 <h4 id="_simplify_startup_with_dir_local"><a class="anchor" href="#_simplify_startup_with_dir_local"></a><a class="link" href="#_simplify_startup_with_dir_local">13.2.2. Simplify startup with dir-local</a></h4>
 <div class="paragraph">
-<p>You can simplify startup flow by a creating a <code>dir-local.el</code> file at project root.</p>
+<p>You can simplify startup flow by a creating a <code>.dir-locals.el</code> file at project root.</p>
 </div>
 <div class="listingblock">
 <div class="content">

--- a/docs/editor-integration.adoc
+++ b/docs/editor-integration.adoc
@@ -59,7 +59,7 @@ cljs.repl> (js/alert "Jurassic Park!")
 
 === Simplify startup with dir-local
 
-You can simplify startup flow by a creating a `dir-local.el` file at project root.
+You can simplify startup flow by a creating a `.dir-locals.el` file at project root.
 
 ```
 ((nil . ((cider-default-cljs-repl . shadow)


### PR DESCRIPTION
The correct name for the Emacs dir locals file is `.dir-locals.el`, not `dir-local.el`.

See https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html