### PR TITLE
Chlorine only has 'Connect Embedded'

### DIFF
--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -6198,7 +6198,7 @@ cljs.repl&gt;</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p>Now, all you have to do is to run the atom command <code>Chlorine: Connect Clojure Socket Repl</code>. This will connect a REPL to evaluate Clojure code. Next you need to run <code>Chlorine: Connect Embeded Clojurescript Repl</code>, and it&#8217;ll connect the ClojureScript REPL too.</p>
+<p>Now, all you have to do is to run the atom command <code>Chlorine: Connect Clojure Socket Repl</code>. This will connect a REPL to evaluate Clojure code. Next you need to run <code>Chlorine: Connect Embedded</code>, and it&#8217;ll connect the ClojureScript REPL too.</p>
 </div>
 <div class="paragraph">
 <p>Now, you can use the <code>Chlorine: Evaluate&#8230;&#8203;</code> commands to evaluate any Clojure or ClojureScript REPL. It&#8217;ll evaluate <code>.clj</code> files as Clojure, and <code>cljc</code> files as ClojureScript.</p>
@@ -6668,7 +6668,7 @@ that project and understand its setup, build, etc.</p>
 <div id="footer">
 <div id="footer-text">
 Version 1.0<br>
-Last updated 2019-11-29 11:36:12 CET
+Last updated 2019-12-24 01:28:38 UTC
 </div>
 </div>
 </body>

--- a/docs/editor-integration.adoc
+++ b/docs/editor-integration.adoc
@@ -108,7 +108,7 @@ Once you checked that the configuration is right, you can start your shadow app 
 $ shadow-cljs watch app
 ```
 
-Now, all you have to do is to run the atom command `Chlorine: Connect Clojure Socket Repl`. This will connect a REPL to evaluate Clojure code. Next you need to run `Chlorine: Connect Embeded Clojurescript Repl`, and it'll connect the ClojureScript REPL too.
+Now, all you have to do is to run the atom command `Chlorine: Connect Clojure Socket Repl`. This will connect a REPL to evaluate Clojure code. Next you need to run `Chlorine: Connect Embedded`, and it'll connect the ClojureScript REPL too.
 
 Now, you can use the `Chlorine: Evaluate...` commands to evaluate any Clojure or ClojureScript REPL. It'll evaluate `.clj` files as Clojure, and `cljc` files as ClojureScript.
 


### PR DESCRIPTION
In previous versions this may have said 'Connect Embedded Clojurescript Repl'
however the current version only has 'Connect Embedded'