### PR TITLE
Update links from CommonConfig to Configuration

### DIFF
--- a/docs/UsersGuide.adoc
+++ b/docs/UsersGuide.adoc
@@ -536,7 +536,7 @@ include::target-react-native.adoc[]
 
 There is built-in support for generating code that is intended to be used as a stand-alone
 script, and also for code that is intended to be used as a library. See the
-section on <<CommonConfig,common configuration>> for the base settings needed in
+section on <<Configuration,common configuration>> for the base settings needed in
 a configuration file.
 
 == node.js Scripts [[target-node-script]]

--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -4110,7 +4110,7 @@ The requests must be forwarded to the main <a href="#http">HTTP server</a>, not 
 <p>The <code>:target :react-native</code> produces code that is meant to integrate into the default <code>react-native</code> tooling (eg. <code>metro</code>). Tools like <code>expo</code> which wrap those tools should automatically work and require no additional setup.</p>
 </div>
 <div class="paragraph">
-<p>You will need the same basic <a href="#CommonConfig">main configuration</a> as in other targets (like
+<p>You will need the same basic <a href="#_configuration">main configuration</a> as in other targets (like
 <code>:source-paths</code>), the build specific config is very minimal and requires at least 2 options (besides <code>:target</code> itself)</p>
 </div>
 <div class="hdlist">
@@ -4207,7 +4207,7 @@ The requests must be forwarded to the main <a href="#http">HTTP server</a>, not 
 <div class="paragraph">
 <p>There is built-in support for generating code that is intended to be used as a stand-alone
 script, and also for code that is intended to be used as a library. See the
-section on <a href="#CommonConfig">common configuration</a> for the base settings needed in
+section on <a href="#_configuration">common configuration</a> for the base settings needed in
 a configuration file.</p>
 </div>
 <div class="sect2">
@@ -4227,7 +4227,7 @@ The code is just ClojureScript, and an entry point is easy to define:</p>
 <div class="sect3">
 <h4 id="_build_options"><a class="anchor" href="#_build_options"></a><a class="link" href="#_build_options">9.1.1. Build Options</a></h4>
 <div class="paragraph">
-<p>You will need the same basic <a href="#CommonConfig">main configuration</a> as in other targets (like
+<p>You will need the same basic <a href="#_configuration">main configuration</a> as in other targets (like
 <code>:source-paths</code>), but you&#8217;ll need some node-specific build target options:</p>
 </div>
 <div class="hdlist">
@@ -4380,7 +4380,7 @@ artifacts used.
 useful for publishing your code for re-use as a compiled Javascript artifact.</p>
 </div>
 <div class="paragraph">
-<p>As with other modes the <a href="#CommonConfig">main configuration options</a> apply and must be set.
+<p>As with other modes the <a href="#_configuration">main configuration options</a> apply and must be set.
 The target-specific options are:</p>
 </div>
 <div class="hdlist">
@@ -4616,7 +4616,7 @@ comes with a convenience mode that makes such integration easier.</p>
 <p>This target is meant to be as easy to access as possible, and does not actually require a specific build in the config. You still need a non-empty config file, but the default one from <code>shadow-cljs init</code> will do.</p>
 </div>
 <div class="paragraph">
-<p>ClojureScript organizes files into namespaces which means that a <code>demo.foo</code> namespace should be inside a <code>src/main/demo/foo.cljs</code> file. Where <code>src/main</code> is the default source path the shadow-cljs tool (see <a href="#CommonConfig">main configuration</a>).</p>
+<p>ClojureScript organizes files into namespaces which means that a <code>demo.foo</code> namespace should be inside a <code>src/main/demo/foo.cljs</code> file. Where <code>src/main</code> is the default source path the shadow-cljs tool (see <a href="#_configuration">main configuration</a>).</p>
 </div>
 <div class="listingblock">
 <div class="title">Sample source for <code>src/main/demo/foo.cljs</code></div>
@@ -4657,7 +4657,7 @@ comes with a convenience mode that makes such integration easier.</p>
 <div class="paragraph">
 <p>You can also treat <code>:npm-module</code> on the same footing with your other builds: give it explicit
 configuration. This allows you to also customize the code generation options. Of course
-you will configure the <a href="#CommonConfig">main configuration</a> as in all targets. The target-specific
+you will configure the <a href="#_configuration">main configuration</a> as in all targets. The target-specific
 options are:</p>
 </div>
 <div class="hdlist">
@@ -6668,7 +6668,7 @@ that project and understand its setup, build, etc.</p>
 <div id="footer">
 <div id="footer-text">
 Version 1.0<br>
-Last updated 2019-11-29 11:36:12 CET
+Last updated 2020-01-09 08:07:32 PST
 </div>
 </div>
 </body>

--- a/docs/target-node-library.adoc
+++ b/docs/target-node-library.adoc
@@ -1,7 +1,7 @@
 The `:target :node-library` emits code that can be used (via `require`) as a standard node library, and is
 useful for publishing your code for re-use as a compiled Javascript artifact.
 
-As with other modes the <<CommonConfig, main configuration options>> apply and must be set.
+As with other modes the <<Configuration, main configuration options>> apply and must be set.
 The target-specific options are:
 
 [horizontal]

--- a/docs/target-node-script.adoc
+++ b/docs/target-node-script.adoc
@@ -10,7 +10,7 @@ The code is just ClojureScript, and an entry point is easy to define:
 
 === Build Options
 
-You will need the same basic <<CommonConfig,main configuration>> as in other targets (like
+You will need the same basic <<Configuration,main configuration>> as in other targets (like
 `:source-paths`), but you'll need some node-specific build target options:
 
 [horizontal]

--- a/docs/target-npm-module.adoc
+++ b/docs/target-npm-module.adoc
@@ -9,7 +9,7 @@ comes with a convenience mode that makes such integration easier.
 
 This target is meant to be as easy to access as possible, and does not actually require a specific build in the config. You still need a non-empty config file, but the default one from `shadow-cljs init` will do.
 
-ClojureScript organizes files into namespaces which means that a `demo.foo` namespace should be inside a `src/main/demo/foo.cljs` file. Where `src/main` is the default source path the shadow-cljs tool (see <<CommonConfig, main configuration>>).
+ClojureScript organizes files into namespaces which means that a `demo.foo` namespace should be inside a `src/main/demo/foo.cljs` file. Where `src/main` is the default source path the shadow-cljs tool (see <<Configuration, main configuration>>).
 
 
 .Sample source for `src/main/demo/foo.cljs`
@@ -43,7 +43,7 @@ Watching with incremental compile is as simple as running `shadow-cljs watch npm
 
 You can also treat `:npm-module` on the same footing with your other builds: give it explicit
 configuration. This allows you to also customize the code generation options. Of course
-you will configure the <<CommonConfig, main configuration>> as in all targets. The target-specific
+you will configure the <<Configuration, main configuration>> as in all targets. The target-specific
 options are:
 
 [horizontal]

--- a/docs/target-react-native.adoc
+++ b/docs/target-react-native.adoc
@@ -1,6 +1,6 @@
 The `:target :react-native` produces code that is meant to integrate into the default `react-native` tooling (eg. `metro`). Tools like `expo` which wrap those tools should automatically work and require no additional setup.
 
-You will need the same basic <<CommonConfig,main configuration>> as in other targets (like
+You will need the same basic <<Configuration,main configuration>> as in other targets (like
 `:source-paths`), the build specific config is very minimal and requires at least 2 options (besides `:target` itself)
 
 [horizontal]


### PR DESCRIPTION
The CommonConfig section was removed in commit 0ed27580. It had the
comment that it was basically duplicate info of Configuration.