### PR TITLE
Added missing trialing semicolon to UsersGuide deps.edn alias

### DIFF
--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -1320,7 +1320,7 @@ It is recommended to still use the <code>shadow-cljs</code> command to run comma
  <span class="symbol">:deps</span> {<span class="keyword">..</span><span class="keyword">.</span>}
  <span class="symbol">:aliases</span>
  {<span class="symbol">:shadow-cljs</span>
-  {<span class="symbol">:extra-deps</span> {thheller/shadow-cljs {<span class="symbol">:mvn/version</span> &lt;latest&gt;}
+  {<span class="symbol">:extra-deps</span> {thheller/shadow-cljs {<span class="symbol">:mvn/version</span> &lt;latest&gt;}}
    <span class="symbol">:main-opts</span> [<span class="string"><span class="delimiter">&quot;</span><span class="content">-m</span><span class="delimiter">&quot;</span></span> <span class="string"><span class="delimiter">&quot;</span><span class="content">shadow.cljs.devtools.cli</span><span class="delimiter">&quot;</span></span>]}}}</code></pre>
 </div>
 </div>


### PR DESCRIPTION
Lack of semicolon caused example to throw below error when used.
```
Coordinate type  not loaded for library :main-opts in coordinate in coordinate ["-m" "shadow.cljs.devtools.cli"]
```

Under section https://shadow-cljs.github.io/docs/UsersGuide.html#deps-edn `Running with clj directly.`