### PR TITLE
Added documentation about the plain react-native

### DIFF
--- a/docs/target-react-native.adoc
+++ b/docs/target-react-native.adoc
@@ -23,6 +23,12 @@ You will need the same basic <<CommonConfig,main configuration>> as in other tar
 
 When compiled this results in a `app/index.js` file intended to be used as an entry point for the `react-native` tools. During development the `:output-dir` will contain many more files but you should only reference the generated `app/index.js` directly. A `release` build will only generated the optimized `app/index.js` and requires no additional files.
 
+== React Native
+
+There are two ways to use `react-native`, "plain" `react-native`, which allows you to use native code and libraries and the one "wrapped" in https://expo.io/[expo] (described below). All the steps described above are sufficient to start using shadow-cljs with the plain `react-native`. See this example repo:
+
+- https://github.com/thheller/reagent-react-native
+
 == Expo
 
 https://expo.io/[expo] makes working with `react-native` quite easy. There are two provided example setups.


### PR DESCRIPTION
Since the steps in the main section are applicable to the plain
react-native setup and since only the Expo section was present,
decided to add this section with the link to the sample repo.

I'm not 100% sure about the way the "plain" `react-native` and Expo `react-native` should be differentiated and described. But figured to create this PR to at least start the discussion. 

What do you think? 

As for the repo linked, it does work and the steps are applicable.
I mainly wanted it in the documentation, since it's relevant and can be run by just following the README.

Thanks