### PR TITLE
Added link to cljs's foreign dep reference.

### DIFF
--- a/docs/maven-publish.adoc
+++ b/docs/maven-publish.adoc
@@ -66,3 +66,5 @@ You can declare `npm` dependencies directly by including a `deps.cljs` with `:np
 
 You can also provide extra `:foreign-libs` definitions here. They won't affect `shadow-cljs` but might help other tools.
 
+See https://clojurescript.org/reference/packaging-foreign-deps for more info.
+


### PR DESCRIPTION
The publishing section references deps.cljs which I wasn't aware of. I think it would be useful to include a link that provides more context for deps.cljs.