### PR TITLE
Make clear that build reports are not affected by already running watches

### DIFF
--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -3455,7 +3455,7 @@ Configs later in the merge order can override, but not remove previous configura
  {<span class="symbol">:app</span> {<span class="symbol">:target</span> <span class="symbol">:browser</span>
         <span class="symbol">:output-dir</span> <span class="string"><span class="delimiter">&quot;</span><span class="content">public/assets/app/js</span><span class="delimiter">&quot;</span></span>
         <span class="symbol">:asset-path</span> <span class="string"><span class="delimiter">&quot;</span><span class="content">/assets/app/js</span><span class="delimiter">&quot;</span></span>
-        <span class="symbol">:modules</span> {<span class="symbol">:main</span> {<span class="symbol">:entries</span> [my.app]}}}]}</code></pre>
+        <span class="symbol">:modules</span> {<span class="symbol">:main</span> {<span class="symbol">:entries</span> [my.app]}}}}}</code></pre>
 </div>
 </div>
 <div class="sect2">
@@ -6261,6 +6261,12 @@ The generated <code>report.html</code> is entirely self-contained and includes a
 </td>
 </tr>
 </table>
+</div>
+<div class="paragraph">
+<p>Any running build watches will not affect the output of the build report.</p>
+</div>
+<div class="paragraph">
+<p>The build report runs separately from any other watches you may have running, you do not need to stop any of them nor do you need to stop the shadow-cljs server before building the report.</p>
 </div>
 </div>
 </div>

--- a/docs/release.adoc
+++ b/docs/release.adoc
@@ -216,7 +216,7 @@ Each of these options is specified as a Set of Strings. Please note that all the
 ****
 
 
-== Build Report [[build-report]] 
+== Build Report [[build-report]]
 
 `shadow-cljs` can generate a detailed report for your `release` builds which includes a detailed breakdown of the included sources and how much they each contributed to the overall size.
 
@@ -231,3 +231,7 @@ $ npx shadow-cljs run shadow.cljs.build-report app report.html
 The above example will generate a `report.html` in the project directory for the `:app` build.
 
 TIP: The generated `report.html` is entirely self-contained and includes all the required data/js/css. No other external sources are required.
+
+Any running build watches will not affect the output of the build report.
+
+The build report runs separately from any other watches you may have running, you do not need to stop any of them nor do you need to stop the shadow-cljs server before building the report.


### PR DESCRIPTION
I was curious about this, so figure someone (maybe my future self) will want to know this too.