### PR TITLE
Document additional :output-feature-set options

### DIFF
--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -3154,6 +3154,9 @@ Note that this mostly affects imported JS code from <a href="#npm">npm</a> or <c
 <div class="ulist">
 <ul>
 <li>
+<p><code>:bare-minimum</code></p>
+</li>
+<li>
 <p><code>:es3</code></p>
 </li>
 <li>
@@ -3166,7 +3169,16 @@ Note that this mostly affects imported JS code from <a href="#npm">npm</a> or <c
 <p><code>:es7</code> - exponent <code>**</code> operator</p>
 </li>
 <li>
-<p><code>:es8</code> - <code>async/await</code>, <code>generators</code>, object literals with spread, &#8230;&#8203;</p>
+<p><code>:es8</code> - <code>async/await</code>, <code>generators</code>, shared memory and atomics</p>
+</li>
+<li>
+<p><code>:es2018</code> - async iteration, <code>Promise.finally</code>, several <code>RegExp</code> features, spread syntax in object literals</p>
+</li>
+<li>
+<p><code>:es2019</code></p>
+</li>
+<li>
+<p><code>:es2020</code> - <code>AsyncIterator</code>, <code>BigInt</code>, <code>??</code> operator, dynamic imports</p>
 </li>
 <li>
 <p><code>:es-next</code> - all the features the Closure Compiler currently supports</p>
@@ -3455,7 +3467,7 @@ Configs later in the merge order can override, but not remove previous configura
  {<span class="symbol">:app</span> {<span class="symbol">:target</span> <span class="symbol">:browser</span>
         <span class="symbol">:output-dir</span> <span class="string"><span class="delimiter">&quot;</span><span class="content">public/assets/app/js</span><span class="delimiter">&quot;</span></span>
         <span class="symbol">:asset-path</span> <span class="string"><span class="delimiter">&quot;</span><span class="content">/assets/app/js</span><span class="delimiter">&quot;</span></span>
-        <span class="symbol">:modules</span> {<span class="symbol">:main</span> {<span class="symbol">:entries</span> [my.app]}}}]}</code></pre>
+        <span class="symbol">:modules</span> {<span class="symbol">:main</span> {<span class="symbol">:entries</span> [my.app]}}}}}</code></pre>
 </div>
 </div>
 <div class="sect2">
@@ -7029,7 +7041,7 @@ that project and understand its setup, build, etc.</p>
 <div id="footer">
 <div id="footer-text">
 Version 1.0<br>
-Last updated 2021-04-13 09:43:28 EDT
+Last updated 2021-05-11 12:53:23 CDT
 </div>
 </div>
 </body>

--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -3183,6 +3183,12 @@ Note that this mostly affects imported JS code from <a href="#npm">npm</a> or <c
 <li>
 <p><code>:es-next</code> - all the features the Closure Compiler currently supports</p>
 </li>
+<li>
+<p><code>:browser-2020</code> - <code>:es2019</code> minus several RegExp features</p>
+</li>
+<li>
+<p><code>:browser-2021</code> - <code>:es2020</code> minus RegExp Unicode properties</p>
+</li>
 </ul>
 </div>
 <div class="listingblock">

--- a/docs/build-config.adoc
+++ b/docs/build-config.adoc
@@ -456,11 +456,15 @@ You can configure this via the `:output-feature-set` in `:compiler-options`. The
 
 Supported options are:
 
+- `:bare-minimum`
 - `:es3`
 - `:es5`
 - `:es6` - `class`, `const`, `let`, ...
 - `:es7` - exponent `**` operator
-- `:es8` - `async/await`, `generators`, object literals with spread, ...
+- `:es8` - `async/await`, `generators`, shared memory and atomics
+- `:es2018` - async iteration, `Promise.finally`, several `RegExp` features, spread syntax in object literals
+- `:es2019`
+- `:es2020` - `AsyncIterator`, `BigInt`, `??` operator, dynamic imports
 - `:es-next` - all the features the Closure Compiler currently supports
 
 .Example

--- a/docs/build-config.adoc
+++ b/docs/build-config.adoc
@@ -466,6 +466,8 @@ Supported options are:
 - `:es2019`
 - `:es2020` - `AsyncIterator`, `BigInt`, `??` operator, dynamic imports
 - `:es-next` - all the features the Closure Compiler currently supports
+- `:browser-2020` - `:es2019` minus several RegExp features
+- `:browser-2021` - `:es2020` minus RegExp Unicode properties
 
 .Example
 ```


### PR DESCRIPTION
I've added `:bare-minimum`, `:es2018`, and `:es2019`, and `:es2020`. The note for `:es8` listed object spread syntax, but that is actually an `:es2018` feature, so I've moved it.

I don't know what `:es-next-in` is for, so I haven't included it.