### PR TITLE
Mention push-state handler checks Accept header

### DIFF
--- a/docs/UsersGuide.adoc
+++ b/docs/UsersGuide.adoc
@@ -480,7 +480,7 @@ The longer config version expects a map and the supported options are:
 `:ssl-port`:: When `:ssl` is configured use this port for ssl connections and server normal HTTP on the regular port. If `:ssl-port` is not set but `:ssl` is configured the default port will only server SSL requests.
 `:host`:: Optional. The hostname to listen on. Defaults to localhost.
 `:handler`:: Optional. A fully qualified symbol. A `(defn handler [req] resp)` that is used
-if a resource is not found for the given request. Defaults to `shadow.http.push-state/handle`.
+if a resource is not found for the given request. Defaults to `shadow.http.push-state/handle` (this handler will only respond to requests with `Accept: text/html` header.)
 
 The following two options only apply when using the default, built-in handler and typically do not need to be changed:
 


### PR DESCRIPTION
The push-state handler will only respond to HTTP requests with "Accept: text/html" headers. Mentioning this in the docs can be helpful if someone is wondering why curl or such tools don't see the same response.

Not sure if this is the best place or if this is confusing detail for some readers, but I think this will be useful to mention.