### PR TITLE
docs: Emacs setup with .dir-locals.el

### DIFF
--- a/docs/editor-integration.adoc
+++ b/docs/editor-integration.adoc
@@ -86,6 +86,8 @@ Or, when watching several builds:
          (cider-shadow-watched-builds . ("<first-build>" "<other-build>")))))
 ```
 
+Read about Emacs and shadow-cljs, using the `.dir-locals.el` file at the https://docs.cider.mx/cider/1.1/cljs/shadow-cljs.html[Cider docs]
+
 == Proto REPL (Atom)
 
 Proto REPL is mostly intended for Clojure development so most features do not work for ClojureScript. It is however possible to use it for simple evals.

--- a/docs/editor-integration.adoc
+++ b/docs/editor-integration.adoc
@@ -78,6 +78,14 @@ You can simplify startup flow by a creating a `.dir-locals.el` file at project r
 	 (cider-shadow-default-options . "<your-build-name-here>"))))
 ```
 
+Or, when watching several builds:
+
+```
+((nil . ((cider-default-cljs-repl . shadow)
+         (cider-shadow-default-options . "<your-build-name-here>")
+         (cider-shadow-watched-builds . ("<first-build>" "<other-build>")))))
+```
+
 == Proto REPL (Atom)
 
 Proto REPL is mostly intended for Clojure development so most features do not work for ClojureScript. It is however possible to use it for simple evals.


### PR DESCRIPTION
Added an alternative `.dir-locals.el` setup when watching several builds.

Also, added a link to the Cider docs about ClojureScript and shadow-cljs configuration options.