### PR TITLE
Docs: Cider with deps.edn and custom init

### DIFF
--- a/docs/editor-integration.adoc
+++ b/docs/editor-integration.adoc
@@ -73,10 +73,44 @@ cljs.repl> (js/alert "Jurassic Park!")
 
 You can simplify startup flow by a creating a `.dir-locals.el` file at project root.
 
-```
+```elisp
 ((nil . ((cider-default-cljs-repl . shadow)
 	 (cider-shadow-default-options . "<your-build-name-here>"))))
 ```
+
+=== Using deps.edn with custom repl intialization.
+
+In case you want to manage your dependencies via https://clojure.org/guides/deps_and_cli[deps.edn], you can use
+custom cljs-repl init form. Create a `:dev` alias with an extra source path of "dev" and add the following
+namespace
+```clj
+(ns user
+  (:require [shadow.cljs.devtools.api :as shadow]
+            [shadow.cljs.devtools.server :as server]))
+
+(defn cljs-repl
+  "Connects to a given build-id. Defaults to `:app`."
+  ([]
+   (cljs-repl :app))
+  ([build-id]
+   (server/start!)
+   (shadow/watch build-id)
+   (shadow/nrepl-select build-id)))
+```
+
+Supposing your build-id is `:app`, add the following to your `.dir-locals.el`
+```elisp
+((nil . ((cider-clojure-cli-global-options . "-A:dev")
+         (cider-preferred-build-tool       . clojure-cli)
+         (cider-default-cljs-repl          . custom)
+         (cider-custom-cljs-repl-init-form . "(do (user/cljs-repl))")
+         (eval . (progn
+                   (make-variable-buffer-local 'cider-jack-in-nrepl-middlewares)
+                   (add-to-list 'cider-jack-in-nrepl-middlewares "shadow.cljs.devtools.server.nrepl/middleware"))))))
+```
+
+`cider-jack-in-cljs` should then work out of the box.
+
 
 == Proto REPL (Atom)
 
@@ -203,7 +237,7 @@ npx shadow-cljs watch frontend
 Open the app in a browser at http://localhost:8080/. Without this step, you would get the following error message from https://www.vim.org/scripts/script.php?script_id=4978[Fireplace.vim] if you attempt to connect to the REPL server from within Vim/Neovim:
 
 ```
-No application has connected to the REPL server. 
+No application has connected to the REPL server.
 Make sure your JS environment has loaded your compiled ClojureScript code.
 ```
 
@@ -214,7 +248,7 @@ Open a ClojureScript source file in Vim/Neovim and execute the following command
 ```
 :Connect 3333
 =>
-Connected to nrepl://localhost:3333/                                                              
+Connected to nrepl://localhost:3333/
 Scope connection to: ~/code/clojurescript/acme-app (ENTER)
 ```
 
@@ -223,7 +257,7 @@ This creates a Clojure (instead of ClojureScript) REPL session. Execute the foll
 ```
 :CljEval (shadow/repl :frontend)
 =>
-To quit, type: :cljs/quit                                                                      
+To quit, type: :cljs/quit
 [:selected :frontend]
 Press ENTER or type command to continue
 ```


### PR DESCRIPTION
This adds documentation of how to set up `cider-jack-in-cljs` with `deps.edn` managed dependencies.