### PR TITLE
fix :node-library link

### DIFF
--- a/docs/UsersGuide.html
+++ b/docs/UsersGuide.html
@@ -5175,7 +5175,7 @@ create-react-app, &#8230;&#8203;) with little configuration.</p>
 <p>If you use the default <code>:output-dir</code> of <code>"node_modules/shadow-cljs"</code> you can access the declared namespaces by using <code>require("shadow-cljs/demo.foo")</code> in JS. When using something not in <code>node_modules</code> you must include them using a relative path. With <code>:output-dir "out"</code> that would be <code>require("./out/demo.foo")</code> from your project root.</p>
 </div>
 <div class="paragraph">
-<p>If you plan to distribute code on NPM, then you may want to use the <a href="#NodeLibrary"><code>:node-library</code> target</a> instead since it allows for a finer level of control over exports and optimization.</p>
+<p>If you plan to distribute code on NPM, then you may want to use the <a href="#target-node-library"><code>:node-library</code> target</a> instead since it allows for a finer level of control over exports and optimization.</p>
 </div>
 <div class="sect2">
 <h3 id="_working_with_optimizations"><a class="anchor" href="#_working_with_optimizations"></a><a class="link" href="#_working_with_optimizations">11.1. Working with Optimizations</a></h3>
@@ -7477,7 +7477,7 @@ that project and understand its setup, build, etc.</p>
 <div id="footer">
 <div id="footer-text">
 Version 1.0<br>
-Last updated 2022-08-05 09:27:21 CEST
+Last updated 2022-09-16 11:56:03 UTC
 </div>
 </div>
 </body>

--- a/docs/target-npm-module.adoc
+++ b/docs/target-npm-module.adoc
@@ -17,7 +17,7 @@ create-react-app, ...) with little configuration.
 
 If you use the default `:output-dir` of `"node_modules/shadow-cljs"` you can access the declared namespaces by using `require("shadow-cljs/demo.foo")` in JS. When using something not in `node_modules` you must include them using a relative path. With `:output-dir "out"` that would be `require("./out/demo.foo")` from your project root.
 
-If you plan to distribute code on NPM, then you may want to use the <<NodeLibrary, `:node-library` target>> instead since it allows for a finer level of control over exports and optimization.
+If you plan to distribute code on NPM, then you may want to use the <<target-node-library, `:node-library` target>> instead since it allows for a finer level of control over exports and optimization.
 
 == Working with Optimizations
 


### PR DESCRIPTION
Link was broken...

ps. The `make docker-build` is pulling `asciidoctor:latest`, which today seemed to be `asciidoctor 2.0.17`. There were some major changes in the output HTML with v2. So I just used the gem version `1.5.6.1` to generate this.