### PR TITLE
Add `:dev/always` to custom `runner-ns` example

### DIFF
--- a/docs/target-browser-test.adoc
+++ b/docs/target-browser-test.adoc
@@ -29,16 +29,24 @@ If you choose to supply a custom `:runner-ns`, it might look like this:
 
 ```
 (ns tests.client-test-main
-  {:dev/always true})
+  {:dev/always true}
+  (:require [shadow.test :as st]
+            [shadow.test.env :as env]
+            [cljs-test-display.core :as ctd]
+            [shadow.dom :as dom]))
 
 (defn start []
-  ... run the tests...)
+  (-> (env/get-test-data)
+      (env/reset-test-data!))
+
+  (st/run-all-tests (ctd/init! "test-root")))
 
 (defn stop [done]
   ; tests can be async. You must call done so that the runner knows you actually finished
   (done))
 
 (defn ^:export init []
+  (dom/append [:div#test-root])
   (start))
 ```
 

--- a/docs/target-browser-test.adoc
+++ b/docs/target-browser-test.adoc
@@ -28,7 +28,8 @@ In general you will need a config that looks like this:
 If you choose to supply a custom `:runner-ns`, it might look like this:
 
 ```
-(ns tests.client-test-main)
+(ns tests.client-test-main
+  {:dev/always true})
 
 (defn start []
   ... run the tests...)


### PR DESCRIPTION
Without it, failing tests disappear when the tests are hot reloaded for the first time