### PR TITLE
Fix default export example

### DIFF
--- a/docs/js-deps.adoc
+++ b/docs/js-deps.adoc
@@ -99,7 +99,7 @@ import defaultExport, * as name from "module-name";
 ```clojure
 (:require
   ["module-name" :as name]
-  ["module-name$export" :as defaultExport])
+  ["module-name$default" :as defaultExport])
 ```
 
 .Example Module Import without use (including a Module for side-effects only)


### PR DESCRIPTION
I believe the example uses `$export` instead of `$default` by mistake.