### PR TITLE
Mention use of `:reload-strategy`

### DIFF
--- a/docs/build-config.adoc
+++ b/docs/build-config.adoc
@@ -109,6 +109,23 @@ In order to use it you simply run:
 shadow-cljs watch build-id
 ```
 
+==== Hot Reload of Transitive Dependents [[reload-strategy]]
+
+By default compiled files and files explicitly requiring those are reloaded. This approach may not be sufficient eg.
+during development for `:react-native` target. To reload also all transitive dependents, use `:reload-strategy`
+option with value `:full` as follows:
+
+```
+{...
+ :builds
+ {:app {:target :react-native
+                :init-fn      some.app/init
+                :output-dir "app"
+                ...
+                :devtools     {:autoload true
+                               :reload-strategy :full}}}}
+```
+
 === Lifecycle Hooks
 
 You can configure the compiler to run functions just before hot code reload brings in updated code, and just after. These are useful for stopping/starting things that would otherwise close over old code.

--- a/docs/target-react-native.adoc
+++ b/docs/target-react-native.adoc
@@ -64,3 +64,7 @@ Both examples were generated using `expo init ...` and the only adjusted change 
 ```
 
 `init` is called once on startup. Since the example doesn't need to do any special setup it just calls `start` directly. `start` will be called repeatedly when `watch` is running each time after the code changes were reloaded. The `reagent.core/as-element` function can be used to generate the required React Element from the reagent hiccup markup.
+
+== Hot Code Reload
+
+React native requires to reload not only compiled files and files explicitly requiring those, but also their transitive dependents, for changes to take effect. To accomplish this, use `:reload-strategy` option as in <<reload-strategy, Hot Reload of Transitive Dependents>>.


### PR DESCRIPTION
In react native all (including transitive) dependents must be reloaded, for change to take effect. For specific cases check out [this repository](https://github.com/lbrdnk/repro__shadow-cljs__reload).