### PR TITLE
Expand on `:module-hash-names` integration

### DIFF
--- a/docs/target-browser.adoc
+++ b/docs/target-browser.adoc
@@ -406,7 +406,8 @@ of generating conflicts. I recommend using the full hash.
 Instead of generating `main.js` it will now generate `main.<hash>.js` in the `:output-dir`.
 
 Since the filename can change with every release it gets a little bit more complicated to include them
-in your HTML. The <<BrowserManifest, Output Manifest>> can help with that.
+in your HTML. If you want to accomplish this with a program external to shadow-cljs, you can find programmatic information about filenames in the <<BrowserManifest, Output Manifest>>.
+If you want to accomplish this as part of the build, have a look at <<Build Configuration, Build Hooks>>, and at https://github.com/thheller/shadow-cljs/blob/9a36743674e7bac457c43761c2ef0cce0423862a/src/main/shadow/html.clj#L28-L60[this hook specifically] for inspiration.
 
 == Output Manifest [[BrowserManifest]]
 


### PR DESCRIPTION
Hi,
just went trough the exercise of writing a script to rewrite my html file to include the main module's hash, only to then find the hooks mechanism and a pre-written hook that does exactly what I need :star_struck: I think having this info here might be helpful to others.

Cheers,
Simon